### PR TITLE
GH Actions to release and publish tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+---
+name: publish
+
+"on":
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  publish:
+    name: Publish a tagged version to the Puppet Forge
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Publish to the Puppet Forge
+        run: >
+          docker run --rm
+          -v ${{ github.workspace }}:/root
+          puppet/pdk:2.5.0.0
+          release --force --skip-changelog --skip-documentation --skip-dependency --skip-validation --forge-token=${{ secrets.forge_token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+---
+name: release
+
+"on":
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release:
+    name: Release a tagged version to GitHub Releases
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ncipollo/release-action@v1.12.0
+        with:
+          makeLatest: true


### PR DESCRIPTION
release: Creates a new github release when a semver-like tag is pushed.
publish: Publishes a new Forge module version when a semver-like tag is pushed.