### PR TITLE
Bump version to 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ For local development, here's the workflow I use and what I recommend you use as
 6. Push up your branch to your fork and make a Pull Request.
 
 
-[pdk]: https://puppet.com/docs/pdk/1.x/pdk.html
+[pdk]: https://www.puppet.com/docs/pdk/2.x/pdk.html
 [litmus]: https://github.com/puppetlabs/puppet_litmus
 [ghactions_checks]: https://github.com/natemccurdy/yumrepos_fact/actions/workflows/checks.yml
 

--- a/metadata.json
+++ b/metadata.json
@@ -7,21 +7,69 @@
   "source": "https://github.com/natemccurdy/yumrepos_fact",
   "project_page": "https://github.com/natemccurdy/yumrepos_fact",
   "issues_url": "https://github.com/natemccurdy/yumrepos_fact/issues",
-  "dependencies": [
-
-  ],
+  "dependencies": [],
   "operatingsystem_support": [
     {
-      "operatingsystem": "RedHat"
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "7",
+        "8"
+      ]
     },
     {
-      "operatingsystem": "CentOS"
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8"
+      ]
     },
     {
-      "operatingsystem": "OracleLinux"
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "7",
+        "8",
+        "9"
+      ]
     },
     {
-      "operatingsystem": "Scientific"
+      "operatingsystem": "Scientific",
+      "operatingsystemrelease": [
+        "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "VirtuozzoLinux",
+      "operatingsystemrelease": [
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Amazon",
+      "operatingsystemrelease": [
+        "2017"
+      ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "Fedora",
+      "operatingsystemrelease": [
+        "35",
+        "36",
+        "37"
+      ]
     }
   ],
   "requirements": [

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "nate-yumrepos_fact",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "author": "Nate McCurdy",
   "summary": "Custom fact that shows the count of yumrepos.",
   "license": "Apache-2.0",


### PR DESCRIPTION
This is considered a major change because of the Puppet version requirement changes to a minimum of 6.0.0.

Also new in this version:
- Update metdata to show support for modern RHEL variants with yum
- Update link to PDK docs in README
- Update CI configs to use GitHub Actions and auto release
